### PR TITLE
Dev v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### 🐛 Bug 修复
+- 🐛 **修复 `export default interface` 解析失败**
+  - 在 `export_declaration` 的 `default` 分支中优先匹配 `interface_declaration`
+  - 修复 hmosworld 项目 `ZonesItem.ets` 接口默认导出解析错误
+  - 支持带泛型、继承、可选属性、方法签名的接口默认导出
+  - 解析成功率保持 93.14% (163/175)
+
 ---
 
 ## [0.1.7] - 2025-10-20

--- a/grammar.js
+++ b/grammar.js
@@ -193,6 +193,7 @@ module.exports = grammar({
         $.function_declaration,  // 无装饰器的函数
         $.variable_declaration,
         seq('default', choice(
+          $.interface_declaration,
           $.component_declaration,
           $.class_declaration,
           $.function_declaration,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -783,6 +783,10 @@
                   "members": [
                     {
                       "type": "SYMBOL",
+                      "name": "interface_declaration"
+                    },
+                    {
+                      "type": "SYMBOL",
                       "name": "component_declaration"
                     },
                     {


### PR DESCRIPTION
📝 相关改动
修改文件:
[grammar.js](https://github.com/Million-mo/tree-sitter-arkts/blob/dev-v0.1.7/grammar.js) - 添加接口默认导出支持
[src/grammar.json](https://github.com/Million-mo/tree-sitter-arkts/blob/dev-v0.1.7/src/grammar.json) - 重新生成的语法定义
[src/parser.c](https://github.com/Million-mo/tree-sitter-arkts/blob/dev-v0.1.7/src/parser.c) - 重新生成的解析器
[CHANGELOG.md](https://github.com/Million-mo/tree-sitter-arkts/blob/dev-v0.1.7/CHANGELOG.md) - 更新日志
提交记录:
0379630 - fix: 支持 export default interface 语法
8c5d7ff - docs: 更新 CHANGELOG.md
🎯 影响范围
✅ 新增支持: export default interface 所有场景
✅ 无回归: 既有的 export default class/function/struct 等语法不受影响
✅ 兼容性: 完全向后兼容，无破坏性变更
📊 性能影响
⚡ 解析性能无明显变化
💾 解析器文件大小增加 ~40KB（src/parser.c）
🔄 编译时间无明显增加
🔍 Review 重点
[grammar.js](file:///Users/million_mo/projects/tree-sitter-arkts/grammar.js) L194-199：interface_declaration 在 choice 中的位置
生成的 [src/grammar.json](file:///Users/million_mo/projects/tree-sitter-arkts/src/grammar.json) 中 default 分支的结构
验证无回归：其他 export default 场景仍正常工作